### PR TITLE
API breaking fix: check if CosmosBFT version is v0.37 or v0.38

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,28 +2,37 @@ export default defineNuxtConfig({
   app: {
     pageTransition: { name: 'page', mode: 'out-in' }
   },
+
   devtools: {
     enabled: false
   },
+
   modules: [
     '@pinia/nuxt',
   ],
+
   plugins: [
     //'~/plugins/sequentialEntrance.js', // only in client side
   ],
+
   css: [
     'vuetify/lib/styles/main.sass',
     '@mdi/font/css/materialdesignicons.min.css'
   ],
+
   build: {
     transpile: ['vuetify', 'qrcode-vue3', 'nuxt-storage', 'lodash'],
   },
+
   vite: {
     define: {
       'process.env.DEBUG': false,
     },
   },
+
   devServer: {
     port: 42022
-  }
+  },
+
+  compatibilityDate: '2024-10-29'
 })

--- a/pages/transactions/index.vue
+++ b/pages/transactions/index.vue
@@ -762,9 +762,25 @@ export default {
   async beforeMount() {
     //await this.$store.dispatch("keplr/checkLogin");
     //await this.$store.dispatch("data/getAllValidators"); 
+    //let's check if CosmosBFT version is v0.37 or v0.38
+      const nodeInfoResponse = await axios.get(
+        cosmosConfig[this.store.chainSelected].apiURL +
+          "/cosmos/base/tendermint/v1beta1/node_info"
+      );
+
+      const minorVersion = parseInt(nodeInfoResponse.data.default_node_info.version.split('.')[1], 10);
+      let paramName;
+      if (minorVersion >= 38) {
+        // For v0.38.x and above
+        paramName = 'query';
+      } else {
+        // For v0.37.x and below
+        paramName = 'events';
+      }
+
       const resultSender = await axios(
         cosmosConfig[this.store.chainSelected].apiURL +
-          "/cosmos/tx/v1beta1/txs?query=message.sender=%27" +
+          "/cosmos/tx/v1beta1/txs?"+paramName+"=message.sender=%27" +
           this.store.addrWallet +
           "%27&limit=" +
           cosmosConfig[this.store.chainSelected].maxTxSender +
@@ -772,7 +788,7 @@ export default {
       );
       const resultRecipient = await axios(
         cosmosConfig[this.store.chainSelected].apiURL +
-          "/cosmos/tx/v1beta1/txs?query=transfer.recipient=%27" +
+          "/cosmos/tx/v1beta1/txs?"+paramName+"=transfer.recipient=%27" +
           this.store.addrWallet +
           "%27&limit=" +
           cosmosConfig[this.store.chainSelected].maxTxRecipient +


### PR DESCRIPTION
This is a temporal fix to work with Tendermint v0.37 and v0.38 (bitcanna-1 & bitcanna-dev-1 respectively) 
THIS PR ONLY AFFECTS DEVNET-1 